### PR TITLE
Parser document fix

### DIFF
--- a/spec/DeFormSpec.php
+++ b/spec/DeFormSpec.php
@@ -8,15 +8,16 @@ use PhpSpec\ObjectBehavior;
 use DeForm\DeForm;
 use DeForm\Element\ElementInterface as Element;
 use DeForm\Request\RequestInterface as Request;
+use DeForm\Document\DocumentInterface as Document;
 use DeForm\Node\NodeInterface as Node;
 
 class DeFormSpec extends ObjectBehavior
 {
-    function let(Node $formNode, Request $request, ValidationHelper $validationHelper)
+    function let(Node $formNode, Document $document, Request $request, ValidationHelper $validationHelper)
     {
         $formNode->getAttribute('name')->willReturn('foo');
 
-        $this->beConstructedWith($formNode, $request, $validationHelper);
+        $this->beConstructedWith($formNode, $document, $request, $validationHelper);
     }
 
     function it_should_check_if_the_form_was_submitted(Request $request)
@@ -198,6 +199,13 @@ class DeFormSpec extends ObjectBehavior
         $validationHelper->updateValidationStatus($elements)->shouldBeCalled();
 
         $this->shouldNotBeValid();
+    }
+
+    function it_renders_document(Document $document)
+    {
+        $document->toHtml()->willReturn('foo');
+
+        $this->render()->shouldReturn('foo');
     }
 
 }

--- a/spec/Factory/FormFactorySpec.php
+++ b/spec/Factory/FormFactorySpec.php
@@ -9,13 +9,12 @@ use DeForm\Node\NodeInterface;
 use DeForm\Factory\ElementFactory;
 use DeForm\Parser\ParserInterface;
 use DeForm\Element\ElementInterface;
+use DeForm\Document\DocumentInterface;
 use DeForm\ValidationHelper as Validator;
 use DeForm\Request\RequestInterface as Request;
 
 class FormFactorySpec extends ObjectBehavior
 {
-
-    protected $html = '<form></form>';
 
     function let(
         Request $request,
@@ -25,11 +24,12 @@ class FormFactorySpec extends ObjectBehavior
         NodeInterface $formNode,
         NodeInterface $textInput,
         NodeInterface $hiddenInput,
-        ElementInterface $textElement
+        ElementInterface $textElement,
+        DocumentInterface $document
     ) {
         $this->beConstructedWith($request, $validator, $elementFactory, $parser);
 
-        $parser->setHtml($this->html)->shouldBeCalled();
+        $parser->setDocument($document)->shouldBeCalled();
         $parser->getFormNode()->willReturn($formNode);
         $parser->getElementsNodes()->willReturn($nodes = [
             $textInput,
@@ -49,22 +49,22 @@ class FormFactorySpec extends ObjectBehavior
         ]);
     }
 
-    function it_makes_deform_object(ElementInterface $textElement)
+    function it_makes_deform_object(ElementInterface $textElement, DocumentInterface $document)
     {
-        $form = $this->make($this->html);
+        $form = $this->make($document);
         $form->shouldHaveType('DeForm\DeForm');
         $form->getElement('foo')->shouldReturn($textElement);
     }
 
-    function it_binds_request(Request $request)
+    function it_binds_request(Request $request, DocumentInterface $document)
     {
-        $form = $this->make($this->html);
+        $form = $this->make($document);
         $request->get(DeForm::DEFORM_ID)->willReturn('testform');
 
         $form->isSubmitted()->shouldReturn(true);
     }
 
-    function it_binds_validator(Request $request, Validator $validator, ElementInterface $textElement)
+    function it_binds_validator(Request $request, Validator $validator, ElementInterface $textElement, DocumentInterface $document)
     {
         $request->get(DeForm::DEFORM_ID)->willReturn('testform');
         $request->get('foo')->willReturn('test');
@@ -76,7 +76,7 @@ class FormFactorySpec extends ObjectBehavior
         $validator->validate(['foo' => 'required'], Argument::any())->shouldBeCalled();
         $validator->updateValidationStatus(Argument::any())->shouldBeCalled();
 
-        $this->make($this->html)
+        $this->make($document)
             ->isValid();
     }
 }

--- a/spec/Parser/HtmlParserSpec.php
+++ b/spec/Parser/HtmlParserSpec.php
@@ -5,6 +5,7 @@ namespace spec\DeForm\Parser;
 use Prophecy\Argument;
 use PhpSpec\ObjectBehavior;
 use DeForm\Document\HtmlDocument;
+use DeForm\Document\DocumentInterface;
 
 class HtmlParserSpec extends ObjectBehavior
 {
@@ -14,22 +15,27 @@ class HtmlParserSpec extends ObjectBehavior
         $this->shouldHaveType('DeForm\Parser\ParserInterface');
     }
 
+    function it_sets_only_html_document(DocumentInterface $document)
+    {
+        $this->shouldThrow('\InvalidArgumentException')->duringSetDocument($document);
+    }
+
     function it_gets_form_node()
     {
-        $this->setHtml('<form method="post"><input type="text" name="foo"/></form>');
+        $document = new HtmlDocument;
+        $document->load('<form method="post"><input type="text" name="foo"/></form>');
+
+        $this->setDocument($document);
 
         $this->getFormNode()->shouldReturnAnInstanceOf('DeForm\Node\HtmlNode');
         $this->getFormNode()->getAttribute('method')->shouldReturn('post');
     }
 
-//    function it_finds_form_element(HtmlDocument $document)
-//    {
-//        // Todo: implement
-//    }
-
     function it_gets_element_nodes()
     {
-        $this->setHtml('<form method="post"><input type="text" name="foo"/><input type="checkbox" name="bar"/></form>');
+        $document = new HtmlDocument;
+        $document->load('<form method="post"><input type="text" name="foo"/><input type="checkbox" name="bar"/></form>');
+        $this->setDocument($document);
 
         $elements = $this->getElementsNodes();
 
@@ -39,5 +45,4 @@ class HtmlParserSpec extends ObjectBehavior
         $elements[1]->shouldBeAnInstanceOf('DeForm\Node\HtmlNode');
         $elements[1]->getElementType()->shouldReturn('input_checkbox');
     }
-
 }

--- a/src/DeForm.php
+++ b/src/DeForm.php
@@ -1,11 +1,11 @@
 <?php namespace DeForm;
 
 use DeForm\Node\NodeInterface;
-use DeForm\Request\RequestInterface;
 use DeForm\Element\ElementInterface;
-use DeForm\Document\DocumentInterface;
 use DeForm\Validation\ValidatorInterface;
+use DeForm\Request\RequestInterface as Request;
 use DeForm\Validation\ValidatorFactoryInterface;
+use DeForm\Document\DocumentInterface as Document;
 
 class DeForm
 {
@@ -42,8 +42,12 @@ class DeForm
      */
     protected $validationHelper;
 
-    public function __construct(NodeInterface $formNode, DocumentInterface $document, RequestInterface $request, ValidationHelper $validationHelper)
-    {
+    public function __construct(
+        NodeInterface $formNode,
+        Document $document,
+        Request $request,
+        ValidationHelper $validationHelper
+    ) {
         $this->formNode = $formNode;
         $this->request = $request;
         $this->validationHelper = $validationHelper;

--- a/src/DeForm.php
+++ b/src/DeForm.php
@@ -3,8 +3,9 @@
 use DeForm\Node\NodeInterface;
 use DeForm\Request\RequestInterface;
 use DeForm\Element\ElementInterface;
-use DeForm\Validation\ValidatorFactoryInterface;
+use DeForm\Document\DocumentInterface;
 use DeForm\Validation\ValidatorInterface;
+use DeForm\Validation\ValidatorFactoryInterface;
 
 class DeForm
 {
@@ -15,6 +16,11 @@ class DeForm
      * @var \DeForm\Node\NodeInterface
      */
     protected $formNode;
+
+    /**
+     * @var \DeForm\Document\DocumentInterface
+     */
+    protected $document;
 
     /**
      * @var \DeForm\Request\RequestInterface
@@ -30,17 +36,18 @@ class DeForm
      * @var bool|null
      */
     protected $valid = null;
-    
+
     /**
      * @var ValidationHelper
      */
     protected $validationHelper;
 
-    public function __construct(NodeInterface $formNode, RequestInterface $request, ValidationHelper $validationHelper)
+    public function __construct(NodeInterface $formNode, DocumentInterface $document, RequestInterface $request, ValidationHelper $validationHelper)
     {
         $this->formNode = $formNode;
         $this->request = $request;
         $this->validationHelper = $validationHelper;
+        $this->document = $document;
     }
 
     /**
@@ -197,5 +204,10 @@ class DeForm
         }
 
         return $data;
+    }
+
+    public function render()
+    {
+        return $this->document->toHtml();
     }
 }

--- a/src/Document/HtmlDocument.php
+++ b/src/Document/HtmlDocument.php
@@ -16,6 +16,8 @@ class HtmlDocument implements DocumentInterface
      */
     public function load($html)
     {
+        $html = mb_convert_encoding($html, 'HTML-ENTITIES', 'UTF-8');
+
         $this->document = new \DOMDocument;
         $this->document->loadHTML($html);
     }

--- a/src/Factory/FormFactory.php
+++ b/src/Factory/FormFactory.php
@@ -4,6 +4,7 @@ use DeForm\DeForm;
 use DeForm\Node\NodeInterface;
 use DeForm\Parser\ParserInterface;
 use DeForm\Factory\ElementFactory;
+use DeForm\Document\DocumentInterface;
 use DeForm\ValidationHelper as Validator;
 use DeForm\Request\RequestInterface as Request;
 
@@ -43,14 +44,14 @@ class FormFactory
     }
 
     /**
-     * Creates new DeForm object based on given HTML
+     * Creates new DeForm object from document
      *
-     * @param string $html
+     * @param \DeForm\Document\DocumentInterface $document
      * @return \DeForm\DeForm
      */
-    public function make($html)
+    public function make(DocumentInterface $document)
     {
-        $this->parser->setHtml($html);
+        $this->parser->setDocument($document);
 
         $form_node = $this->parser->getFormNode();
         $hidden_input = $form_node->createElement('input');

--- a/src/Factory/FormFactory.php
+++ b/src/Factory/FormFactory.php
@@ -60,7 +60,7 @@ class FormFactory
         $hidden_input->setAttribute('name', DeForm::DEFORM_ID);
         $form_node->appendChild($hidden_input);
 
-        $form = new DeForm($form_node, $this->request, $this->validator);
+        $form = new DeForm($form_node, $document, $this->request, $this->validator);
         $elements = $this->elementFactory->createFromNodes($this->parser->getElementsNodes());
 
         array_walk($elements, [$form, 'addElement']);

--- a/src/Parser/HtmlParser.php
+++ b/src/Parser/HtmlParser.php
@@ -1,21 +1,12 @@
 <?php namespace DeForm\Parser;
 
-use DeForm\Document\HtmlDocument;
 use DeForm\Node\HtmlNode;
+use DeForm\Document\HtmlDocument;
 use DeForm\Parser\ParserInterface;
+use DeForm\Document\DocumentInterface;
 
 class HtmlParser implements ParserInterface
 {
-
-    /**
-     * @var string
-     */
-    protected $html;
-
-    /**
-     * @var \DOMDocument
-     */
-    protected $document;
 
     /**
      * @var \DeForm\Node\HtmlNode
@@ -26,6 +17,11 @@ class HtmlParser implements ParserInterface
      * @var \DeForm\Node\HtmlNode[]
      */
     protected $elementNodes = null;
+
+    /**
+     * @var \DeForm\Document\HtmlDocument
+     */
+    protected $document;
 
     protected $map = array(
         '//input[@type="text" or @type="password" or @type="email" or @type="date" or @type="hidden"]',
@@ -38,17 +34,14 @@ class HtmlParser implements ParserInterface
         '//select',
     );
 
-    /**
-     * @param string $html
-     * @return $this
-     */
-    public function setHtml($html)
+    public function setDocument(DocumentInterface $document)
     {
-        $this->html = $html;
 
-        $this->prepareDocument();
+        if (false === $document instanceof HtmlDocument) {
+            throw new \InvalidArgumentException('Only HtmlDocument allowed');
+        }
 
-        return $this;
+        $this->document = $document;
     }
 
     /**
@@ -72,7 +65,7 @@ class HtmlParser implements ParserInterface
      */
     protected function fetchFormNode()
     {
-        $xpath = new \DOMXpath($this->getDocument());
+        $xpath = new \DOMXpath($this->document->getDocument());
         $list = $xpath->query("//form");
 
         if (0 == $list->length) {
@@ -83,7 +76,7 @@ class HtmlParser implements ParserInterface
             throw new \InvalidArgumentException("More than one form found in passed HTML");
         }
 
-        return new HtmlNode($list->item(0), $this->getDocument());
+        return new HtmlNode($list->item(0), $this->document->getDocument());
     }
 
     /**
@@ -100,25 +93,6 @@ class HtmlParser implements ParserInterface
         return $this->elementNodes;
     }
 
-    protected function prepareDocument()
-    {
-        if (true === empty($this->html)) {
-            return;
-        }
-
-        $html = mb_convert_encoding($this->html, 'HTML-ENTITIES', 'UTF-8');
-        $this->document = new \DOMDocument();
-        $this->document->loadHTML($html);
-    }
-
-    /**
-     * @return \DOMDocument
-     */
-    protected function getDocument()
-    {
-        return $this->document;
-    }
-
     /**
      * Searches for form elements in HTML code
      *
@@ -126,7 +100,7 @@ class HtmlParser implements ParserInterface
      */
     protected function fetchElementNodes()
     {
-        $xpath = new \DOMXpath($this->getDocument());
+        $xpath = new \DOMXpath($this->document->getDocument());
         $elements = [];
 
         foreach ($this->map as $query) {
@@ -137,7 +111,7 @@ class HtmlParser implements ParserInterface
             }
 
             foreach ($list as $node) {
-                $elements[] = new HtmlNode($node, $this->getDocument());
+                $elements[] = new HtmlNode($node, $this->document->getDocument());
             }
         }
 

--- a/src/Parser/HtmlParser.php
+++ b/src/Parser/HtmlParser.php
@@ -65,18 +65,17 @@ class HtmlParser implements ParserInterface
      */
     protected function fetchFormNode()
     {
-        $xpath = new \DOMXpath($this->document->getDocument());
-        $list = $xpath->query("//form");
+        $list = $this->document->xpath('//form');
 
-        if (0 == $list->length) {
+        if (0 == count($list)) {
             throw new \InvalidArgumentException("Form element not found in passed HTML");
         }
 
-        if (1 < $list->length) {
+        if (1 < count($list)) {
             throw new \InvalidArgumentException("More than one form found in passed HTML");
         }
 
-        return new HtmlNode($list->item(0), $this->document->getDocument());
+        return new HtmlNode($list[0], $this->document->getDocument());
     }
 
     /**
@@ -100,13 +99,12 @@ class HtmlParser implements ParserInterface
      */
     protected function fetchElementNodes()
     {
-        $xpath = new \DOMXpath($this->document->getDocument());
         $elements = [];
 
         foreach ($this->map as $query) {
-            $list = $xpath->query($query);
+            $list = $this->document->xpath($query);
 
-            if (0 == $list->length) {
+            if (0 == count($list)) {
                 continue;
             }
 

--- a/src/Parser/ParserInterface.php
+++ b/src/Parser/ParserInterface.php
@@ -1,14 +1,16 @@
 <?php namespace DeForm\Parser;
 
+use DeForm\Document\DocumentInterface;
+
 interface ParserInterface
 {
 
     /**
-     * Set the html being parsed
+     * Set parsed document
      *
-     * @param string $html
+     * @param \DeForm\Document\DocumentInterface $document
      */
-    public function setHtml($html);
+    public function setDocument(DocumentInterface $document);
 
     /**
      * Returns main DOM node of the whole form


### PR DESCRIPTION
I've tried to use DeForm in a simple app. As it turned out we forgot about `render()` method :)
I had to rewrite some parts so that we can make proper use of `DocumentInterface`.

Added:
- `DeForm::render()`
- `ParserInterface::setDocument()`

Changes:
- `HtmlParser` is making use of `HtmlDocument::xpath()`
- `FormFactory::make()` requires `DocumentInterface` instance instead of HTML string
- `HtmlDocument` is converting html entities to utf-8
