### PR TITLE
Parser factory

### DIFF
--- a/spec/Document/HtmlDocumentSpec.php
+++ b/spec/Document/HtmlDocumentSpec.php
@@ -11,7 +11,7 @@ class HtmlDocumentSpec extends ObjectBehavior
     function let()
     {
         $this->html = '<div><form method="post"><input type="password" name="pwd"></form></div>';
-        $this->load($this->html);
+        $this->beConstructedWith($this->html);
     }
 
     function it_should_load_a_string_and_convert_it_to_domdocument()

--- a/spec/Factory/HtmlParserFactorySpec.php
+++ b/spec/Factory/HtmlParserFactorySpec.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace spec\DeForm\Factory;
+
+use Prophecy\Argument;
+use PhpSpec\ObjectBehavior;
+use DeForm\Document\HtmlDocument;
+
+class HtmlParserFactorySpec extends ObjectBehavior
+{
+    function it_is_initializable()
+    {
+        $this->shouldHaveType('DeForm\Factory\HtmlParserFactory');
+        $this->shouldImplement('DeForm\Factory\ParserFactoryInterface');
+    }
+
+    function it_creates_document()
+    {
+        $document = $this->createDocument($html = '<form></form>');
+        $document->shouldHaveType('DeForm\Document\HtmlDocument');
+        $document->toHtml()->shouldReturn($html);
+    }
+
+    function it_creates_parser(HtmlDocument $document)
+    {
+        $this->createParser($document)->shouldHaveType('DeForm\Parser\HtmlParser');
+    }
+}

--- a/spec/Parser/HtmlParserSpec.php
+++ b/spec/Parser/HtmlParserSpec.php
@@ -5,27 +5,15 @@ namespace spec\DeForm\Parser;
 use Prophecy\Argument;
 use PhpSpec\ObjectBehavior;
 use DeForm\Document\HtmlDocument;
-use DeForm\Document\DocumentInterface;
 
 class HtmlParserSpec extends ObjectBehavior
 {
 
-    function it_is_initializable()
-    {
-        $this->shouldHaveType('DeForm\Parser\ParserInterface');
-    }
-
-    function it_sets_only_html_document(DocumentInterface $document)
-    {
-        $this->shouldThrow('\InvalidArgumentException')->duringSetDocument($document);
-    }
-
     function it_gets_form_node()
     {
-        $document = new HtmlDocument;
-        $document->load('<form method="post"><input type="text" name="foo"/></form>');
+        $document = new HtmlDocument('<form method="post"><input type="text" name="foo"/></form>');
 
-        $this->setDocument($document);
+        $this->beConstructedWith($document);
 
         $this->getFormNode()->shouldReturnAnInstanceOf('DeForm\Node\HtmlNode');
         $this->getFormNode()->getAttribute('method')->shouldReturn('post');
@@ -33,9 +21,8 @@ class HtmlParserSpec extends ObjectBehavior
 
     function it_gets_element_nodes()
     {
-        $document = new HtmlDocument;
-        $document->load('<form method="post"><input type="text" name="foo"/><input type="checkbox" name="bar"/></form>');
-        $this->setDocument($document);
+        $document = new HtmlDocument('<form method="post"><input type="text" name="foo"/><input type="checkbox" name="bar"/></form>');
+        $this->beConstructedWith($document);
 
         $elements = $this->getElementsNodes();
 

--- a/src/Document/DocumentInterface.php
+++ b/src/Document/DocumentInterface.php
@@ -4,14 +4,6 @@ interface DocumentInterface
 {
 
     /**
-     * Load HTML into document.
-     *
-     * @param string $html
-     * @return void
-     */
-    public function load($html);
-
-    /**
      * Convert document to HTML.
      *
      * @return string

--- a/src/Document/HtmlDocument.php
+++ b/src/Document/HtmlDocument.php
@@ -9,12 +9,9 @@ class HtmlDocument implements DocumentInterface
     protected $document;
 
     /**
-     * Load HTML into document.
-     *
      * @param string $html
-     * @return void
      */
-    public function load($html)
+    public function __construct($html)
     {
         $html = mb_convert_encoding($html, 'HTML-ENTITIES', 'UTF-8');
 

--- a/src/Factory/HtmlParserFactory.php
+++ b/src/Factory/HtmlParserFactory.php
@@ -1,0 +1,18 @@
+<?php namespace DeForm\Factory;
+
+use DeForm\Parser\HtmlParser;
+use DeForm\Document\HtmlDocument;
+
+class HtmlParserFactory implements ParserFactoryInterface
+{
+
+    public function createDocument($html)
+    {
+        return new HtmlDocument($html);
+    }
+
+    public function createParser($document)
+    {
+        return new HtmlParser($document);
+    }
+}

--- a/src/Factory/ParserFactoryInterface.php
+++ b/src/Factory/ParserFactoryInterface.php
@@ -1,0 +1,9 @@
+<?php namespace DeForm\Factory;
+
+interface ParserFactoryInterface
+{
+
+    public function createDocument($html);
+
+    public function createParser($document);
+}

--- a/src/Parser/HtmlParser.php
+++ b/src/Parser/HtmlParser.php
@@ -34,13 +34,8 @@ class HtmlParser implements ParserInterface
         '//select',
     );
 
-    public function setDocument(DocumentInterface $document)
+    public function __construct(HtmlDocument $document)
     {
-
-        if (false === $document instanceof HtmlDocument) {
-            throw new \InvalidArgumentException('Only HtmlDocument allowed');
-        }
-
         $this->document = $document;
     }
 

--- a/src/Parser/ParserInterface.php
+++ b/src/Parser/ParserInterface.php
@@ -6,13 +6,6 @@ interface ParserInterface
 {
 
     /**
-     * Set parsed document
-     *
-     * @param \DeForm\Document\DocumentInterface $document
-     */
-    public function setDocument(DocumentInterface $document);
-
-    /**
      * Returns main DOM node of the whole form
      *
      * @return \DeForm\Node\NodeInterface


### PR DESCRIPTION
Another change related to `DocumentInterface`. As it turned out passing it to `FormFactory::make()` wasn't a good idea (tried to integrate it in Laravel ServiceProvider and it was cumbersome).

This PR introduces `ParserFactoryInterface` which is responsible for creating `DocumentInterface` and `ParserInterface`. Thanks to this, we can encapsulate the process of making documents/parsers of given type. 

Added:
- `ParserFactoryInterface`
- `HtmlParserFactory`

Changed:
- `FormFactory` is using `ParserFactoryInterface`

Removed:
- `DocumentInterface::load()`
- `HtmlParser::setDocument()`
